### PR TITLE
Fix: Make width and height props optional in TypeScript

### DIFF
--- a/src/utils/exportGenerator.ts
+++ b/src/utils/exportGenerator.ts
@@ -99,6 +99,8 @@ import * as React from 'react'
     writeStream.write(`export interface LogoProps extends React.SVGProps<SVGSVGElement> {
   size?: number | string
   color?: string
+  width?: number | string
+  height?: number | string
 }
 
 `);


### PR DESCRIPTION
## Description
Fixes issue #2 by making width and height props optional in the TypeScript interface for logo components.

## Problem
The TypeScript interface was missing width and height properties, causing TypeScript errors when using components without explicitly providing these props, even though they should be optional.

## Solution
Added `width?` and `height?` as optional properties to the `LogoProps` interface.

## Testing
✅ Tested with TypeScript project
✅ No errors when using only `size` prop
✅ No errors when using only `className` 
✅ No errors when using no props (defaults)
✅ Still works with explicit width/height

## Example Usage
```tsx
// All of these now work without TypeScript errors:
<TeslaLogo size={48} />
<TeslaLogo className="w-8 h-8" />
<TeslaLogo />
<TeslaLogo width={40} height={40} />
```

Fixes #2